### PR TITLE
fix: OLLAMA_HOST configuration and add AI endpoint tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - ollama
     environment:
       - OLLAMA_HOST=http://ollama:11434
+      - OLLAMA_MODEL=llama3.2:1b
     volumes: []
     restart: unless-stopped
 

--- a/flow_api.py
+++ b/flow_api.py
@@ -52,7 +52,7 @@ app = FastAPI(
 )
 
 # Set Ollama host from environment or use default
-OLLAMA_HOST = os.getenv("OLLAMA_HOST", "http://192.168.1.248:11435")
+OLLAMA_HOST = os.getenv("OLLAMA_HOST", "http://ollama:11434")
 logger.info("Ollama host configured: %s", OLLAMA_HOST)
 
 

--- a/test_ai_endpoints.sh
+++ b/test_ai_endpoints.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./test_ai_endpoints.sh [BASE_URL] [SYMBOL]
+# Example: ./test_ai_endpoints.sh http://192.168.1.248:8000 CHTR
+
+BASE_URL="${1:-http://192.168.1.248:8000}"
+SYMBOL="${2:-CHTR}"
+
+# If default URL fails and no arg provided, try localhost
+if [[ -z "${1:-}" ]]; then
+  if ! curl -sS --max-time 3 "$BASE_URL/" >/dev/null 2>&1; then
+    ALT="http://localhost:8000"
+    if curl -sS --max-time 3 "$ALT/" >/dev/null 2>&1; then
+      BASE_URL="$ALT"
+    fi
+  fi
+fi
+
+echo "Testing AI endpoints at: $BASE_URL"
+echo "Using symbol: $SYMBOL"
+
+echo
+request() {
+  local path="$1"
+  echo "=== GET $BASE_URL$path ==="
+  curl -sS -w "\nHTTP_STATUS:%{http_code}\n" "$BASE_URL$path" || true
+  echo
+}
+
+# AI Endpoints
+request "/api/ai/fundamental-analysis/$SYMBOL"
+request "/api/ai/technical-analysis/$SYMBOL"
+request "/api/ai/action-recommendation/$SYMBOL"
+request "/api/ai/action-recommendation-sentence/$SYMBOL"
+request "/api/ai/action-recommendation-word/$SYMBOL"


### PR DESCRIPTION
- Fix OLLAMA_HOST in flow_api.py to use Docker service name (ollama:11434) instead of hardcoded external IP (192.168.1.248:11435)
- Add OLLAMA_MODEL environment variable to docker-compose.yml (llama3.2:1b)
- Create test_ai_endpoints.sh script to validate all 5 AI endpoints
- Enables proper Ollama connectivity within Docker network for LLM-powered stock analysis